### PR TITLE
Add Scope Parameter

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,8 @@ toc::[]
 
 === Added
 
+* coroutineScope as parameter to the ClientFactory.
+
 === Changed
 
 === Deprecated

--- a/data-donation-sdk/src/androidTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowAndroidModuleTest.kt
+++ b/data-donation-sdk/src/androidTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowAndroidModuleTest.kt
@@ -42,9 +42,11 @@ import care.data4life.datadonation.networking.plugin.resolveKtorPlugins
 import care.data4life.datadonation.networking.resolveNetworking
 import care.data4life.datadonation.session.resolveSessionKoinModule
 import care.data4life.sdk.util.test.coroutine.runBlockingTest
+import care.data4life.sdk.util.test.coroutine.testCoroutineContext
 import care.data4life.sdk.util.test.ktor.HttpMockClientFactory.createMockClientWithResponse
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.catch
@@ -84,7 +86,8 @@ class ClientConsentFlowAndroidModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/Client.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/Client.kt
@@ -39,6 +39,7 @@ import care.data4life.datadonation.consent.userconsent.UserConsentContract
 import care.data4life.datadonation.di.initKoin
 import care.data4life.sdk.flow.D4LSDKFlow
 import care.data4life.sdk.flow.D4LSDKFlowFactoryContract
+import care.data4life.sdk.util.coroutine.CoroutineScopeFactory
 import care.data4life.sdk.util.coroutine.DomainErrorMapperContract
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
@@ -115,12 +116,16 @@ class Client internal constructor(
     companion object Factory : DataDonationSDK.DataDonationClientFactory {
         override fun getInstance(
             environment: DataDonationSDK.Environment,
-            userSession: DataDonationSDK.UserSessionTokenProvider
+            userSession: DataDonationSDK.UserSessionTokenProvider,
+            coroutineScope: CoroutineScope?
         ): DataDonationSDK.DataDonationClient {
             return Client(
                 initKoin(
                     environment,
-                    userSession
+                    userSession,
+                    coroutineScope ?: CoroutineScopeFactory.createScope(
+                        "DataDonationBackgroundThreadScope"
+                    )
                 )
             )
         }

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/Client.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/Client.kt
@@ -39,7 +39,6 @@ import care.data4life.datadonation.consent.userconsent.UserConsentContract
 import care.data4life.datadonation.di.initKoin
 import care.data4life.sdk.flow.D4LSDKFlow
 import care.data4life.sdk.flow.D4LSDKFlowFactoryContract
-import care.data4life.sdk.util.coroutine.CoroutineScopeFactory
 import care.data4life.sdk.util.coroutine.DomainErrorMapperContract
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
@@ -123,9 +122,7 @@ class Client internal constructor(
                 initKoin(
                     environment,
                     userSession,
-                    coroutineScope ?: CoroutineScopeFactory.createScope(
-                        "DataDonationBackgroundThreadScope"
-                    )
+                    coroutineScope
                 )
             )
         }

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/DataDonationSDK.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/DataDonationSDK.kt
@@ -35,6 +35,7 @@ package care.data4life.datadonation
 import care.data4life.datadonation.ConsentDataContract.ConsentDocument
 import care.data4life.datadonation.ConsentDataContract.UserConsent
 import care.data4life.sdk.flow.D4LSDKFlow
+import kotlinx.coroutines.CoroutineScope
 
 interface DataDonationSDK {
     enum class Environment(val url: String) {
@@ -73,7 +74,8 @@ interface DataDonationSDK {
     interface DataDonationClientFactory {
         fun getInstance(
             environment: Environment,
-            userSession: UserSessionTokenProvider
+            userSession: UserSessionTokenProvider,
+            coroutineScope: CoroutineScope? = null
         ): DataDonationClient
     }
 }

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/di/koin.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/di/koin.kt
@@ -26,6 +26,7 @@ import care.data4life.datadonation.networking.resolveNetworking
 import care.data4life.datadonation.session.resolveSessionKoinModule
 import care.data4life.sdk.flow.D4LSDKFlow
 import care.data4life.sdk.flow.D4LSDKFlowFactoryContract
+import care.data4life.sdk.util.coroutine.CoroutineScopeFactory
 import care.data4life.sdk.util.coroutine.DomainErrorMapperContract
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Clock
@@ -37,14 +38,18 @@ import org.koin.dsl.module
 internal fun initKoin(
     environment: Environment,
     userSession: DataDonationSDK.UserSessionTokenProvider,
-    coroutineScope: CoroutineScope
+    coroutineScope: CoroutineScope?
 ): KoinApplication {
+    val scope = coroutineScope ?: CoroutineScopeFactory.createScope(
+        "DataDonationBackgroundThreadScope"
+    )
+
     return koinApplication {
         modules(
             resolveRootModule(
                 environment,
                 userSession,
-                coroutineScope
+                scope
             ),
             resolveNetworking(),
             resolveKtorPlugins(),

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/di/koin.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/di/koin.kt
@@ -26,7 +26,6 @@ import care.data4life.datadonation.networking.resolveNetworking
 import care.data4life.datadonation.session.resolveSessionKoinModule
 import care.data4life.sdk.flow.D4LSDKFlow
 import care.data4life.sdk.flow.D4LSDKFlowFactoryContract
-import care.data4life.sdk.util.coroutine.CoroutineScopeFactory
 import care.data4life.sdk.util.coroutine.DomainErrorMapperContract
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Clock
@@ -37,13 +36,15 @@ import org.koin.dsl.module
 
 internal fun initKoin(
     environment: Environment,
-    userSession: DataDonationSDK.UserSessionTokenProvider
+    userSession: DataDonationSDK.UserSessionTokenProvider,
+    coroutineScope: CoroutineScope
 ): KoinApplication {
     return koinApplication {
         modules(
             resolveRootModule(
                 environment,
-                userSession
+                userSession,
+                coroutineScope
             ),
             resolveNetworking(),
             resolveKtorPlugins(),
@@ -56,7 +57,8 @@ internal fun initKoin(
 
 internal fun resolveRootModule(
     environment: Environment,
-    userSessionTokenProvider: DataDonationSDK.UserSessionTokenProvider
+    userSessionTokenProvider: DataDonationSDK.UserSessionTokenProvider,
+    coroutineScope: CoroutineScope
 ): Module {
     return module {
         single<Environment> { environment }
@@ -68,7 +70,7 @@ internal fun resolveRootModule(
         }
 
         single<CoroutineScope> {
-            CoroutineScopeFactory.createScope("DataDonationBackgroundThreadScope")
+            coroutineScope
         }
 
         single<DomainErrorMapperContract> {

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/KoinTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/KoinTest.kt
@@ -26,6 +26,7 @@ import org.koin.core.context.stopKoin
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 class KoinTest {
     @BeforeTest
@@ -57,5 +58,38 @@ class KoinTest {
         // Then
         val controller: ConsentDocumentContract.Controller = app.koin.get()
         assertNotNull(controller)
+    }
+
+    @Test
+    fun `Given initKoin is called with its appropriate parameter, which contain null, the resulting KoinApplication contains the given CoroutineScope`() {
+        // Given
+        val scope = CoroutineScope(testCoroutineContext)
+
+        // When
+        val app = initKoin(
+            Environment.DEV,
+            UserSessionTokenProviderStub(),
+            scope
+        )
+
+        // Then
+        assertSame(
+            actual = app.koin.get(),
+            expected = scope
+        )
+    }
+
+    @Test
+    fun `Given initKoin is called with its appropriate parameter, which contain null, the resulting KoinApplication contains a CoroutineScope`() {
+        // When
+        val app = initKoin(
+            Environment.DEV,
+            UserSessionTokenProviderStub(),
+            null
+        )
+
+        // Then
+        val scope: CoroutineScope = app.koin.get()
+        assertNotNull(scope)
     }
 }

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/KoinTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/KoinTest.kt
@@ -20,6 +20,8 @@ import care.data4life.datadonation.DataDonationSDK.Environment
 import care.data4life.datadonation.consent.consentdocument.ConsentDocumentContract
 import care.data4life.datadonation.consent.userconsent.UserConsentContract
 import care.data4life.datadonation.mock.stub.UserSessionTokenProviderStub
+import care.data4life.sdk.util.test.coroutine.testCoroutineContext
+import kotlinx.coroutines.CoroutineScope
 import org.koin.core.context.stopKoin
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -36,7 +38,8 @@ class KoinTest {
         // When
         val app = initKoin(
             Environment.DEV,
-            UserSessionTokenProviderStub()
+            UserSessionTokenProviderStub(),
+            CoroutineScope(testCoroutineContext)
         )
         // Then
         val controller: UserConsentContract.Controller = app.koin.get()
@@ -48,7 +51,8 @@ class KoinTest {
         // When
         val app = initKoin(
             Environment.DEV,
-            UserSessionTokenProviderStub()
+            UserSessionTokenProviderStub(),
+            CoroutineScope(testCoroutineContext)
         )
         // Then
         val controller: ConsentDocumentContract.Controller = app.koin.get()

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/RootKoinTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/RootKoinTest.kt
@@ -20,6 +20,7 @@ import care.data4life.datadonation.DataDonationSDK
 import care.data4life.datadonation.mock.stub.UserSessionTokenProviderStub
 import care.data4life.sdk.flow.D4LSDKFlowFactoryContract
 import care.data4life.sdk.util.coroutine.DomainErrorMapperContract
+import care.data4life.sdk.util.test.coroutine.testCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Clock
 import org.koin.core.context.stopKoin
@@ -27,6 +28,7 @@ import org.koin.dsl.koinApplication
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 class RootKoinTest {
     @BeforeTest
@@ -39,19 +41,24 @@ class RootKoinTest {
         // Given
         val env = DataDonationSDK.Environment.DEV
         val provider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }
+
         // Then
-        val builder: DataDonationSDK.Environment = koin.koin.get()
-        assertNotNull(builder)
+        assertSame(
+            actual = koin.koin.get(),
+            expected = env
+        )
     }
 
     @Test
@@ -59,16 +66,19 @@ class RootKoinTest {
         // Given
         val env = DataDonationSDK.Environment.DEV
         val provider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }
+
         // Then
         val clock: Clock = koin.koin.get()
         assertNotNull(clock)
@@ -78,20 +88,25 @@ class RootKoinTest {
     fun `Given resolveRootModule is called with its appropriate parameter it creates a Module, which contains a UserSessionTokenProvider`() {
         // Given
         val env = DataDonationSDK.Environment.DEV
-        val provider = UserSessionTokenProviderStub()
+        val provider: DataDonationSDK.UserSessionTokenProvider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }
+
         // Then
-        val item: DataDonationSDK.UserSessionTokenProvider = koin.koin.get()
-        assertNotNull(item)
+        assertSame(
+            actual = koin.koin.get(),
+            expected = provider
+        )
     }
 
     @Test
@@ -99,19 +114,25 @@ class RootKoinTest {
         // Given
         val env = DataDonationSDK.Environment.DEV
         val provider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }
         // Then
-        val scope: CoroutineScope = koin.koin.get()
-        assertNotNull(scope)
+
+        // Then
+        assertSame(
+            actual = koin.koin.get(),
+            expected = scope
+        )
     }
 
     @Test
@@ -119,13 +140,15 @@ class RootKoinTest {
         // Given
         val env = DataDonationSDK.Environment.DEV
         val provider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }
@@ -139,13 +162,15 @@ class RootKoinTest {
         // Given
         val env = DataDonationSDK.Environment.DEV
         val provider = UserSessionTokenProviderStub()
+        val scope = CoroutineScope(testCoroutineContext)
 
         // When
         val koin = koinApplication {
             modules(
                 resolveRootModule(
                     env,
-                    provider
+                    provider,
+                    scope
                 )
             )
         }

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/RootKoinTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/di/RootKoinTest.kt
@@ -126,7 +126,6 @@ class RootKoinTest {
                 )
             )
         }
-        // Then
 
         // Then
         assertSame(
@@ -152,6 +151,7 @@ class RootKoinTest {
                 )
             )
         }
+
         // Then
         val mapper: DomainErrorMapperContract = koin.koin.get()
         assertNotNull(mapper)
@@ -174,6 +174,7 @@ class RootKoinTest {
                 )
             )
         }
+
         // Then
         val factory: D4LSDKFlowFactoryContract = koin.koin.get()
         assertNotNull(factory)

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowModuleTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowModuleTest.kt
@@ -46,6 +46,7 @@ import care.data4life.datadonation.networking.resolveNetworking
 import care.data4life.datadonation.session.SessionTokenRepositoryContract.Companion.CACHE_LIFETIME_IN_SECONDS
 import care.data4life.datadonation.session.resolveSessionKoinModule
 import care.data4life.sdk.util.test.coroutine.runWithContextBlockingTest
+import care.data4life.sdk.util.test.coroutine.testCoroutineContext
 import care.data4life.sdk.util.test.ktor.HttpMockClientFactory.createMockClientWithResponse
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteReadPacket
@@ -54,6 +55,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.util.KtorExperimentalAPI
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -108,7 +110,8 @@ class ClientConsentFlowModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),
@@ -173,7 +176,8 @@ class ClientConsentFlowModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),
@@ -265,7 +269,8 @@ class ClientConsentFlowModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),
@@ -365,7 +370,8 @@ class ClientConsentFlowModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),

--- a/data-donation-sdk/src/iosTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowIosModuleTest.kt
+++ b/data-donation-sdk/src/iosTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowIosModuleTest.kt
@@ -42,9 +42,11 @@ import care.data4life.datadonation.networking.plugin.resolveKtorPlugins
 import care.data4life.datadonation.networking.resolveNetworking
 import care.data4life.datadonation.session.resolveSessionKoinModule
 import care.data4life.sdk.util.test.coroutine.runBlockingTest
+import care.data4life.sdk.util.test.coroutine.testCoroutineContext
 import care.data4life.sdk.util.test.ktor.HttpMockClientFactory.createMockClientWithResponse
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -82,7 +84,8 @@ class ClientConsentFlowIosModuleTest {
             modules(
                 resolveRootModule(
                     DataDonationSDK.Environment.DEV,
-                    UserSessionTokenProvider
+                    UserSessionTokenProvider,
+                    CoroutineScope(testCoroutineContext)
                 ),
                 resolveNetworking(),
                 resolveKtorPlugins(),

--- a/swift/DataDonationExample/Services/DataDonationSDKService.swift
+++ b/swift/DataDonationExample/Services/DataDonationSDKService.swift
@@ -23,7 +23,11 @@ final class DataDonationSDKService {
     private let client: DataDonationClientProtocol!
     init(userSessionProvider: UserSessionTokenProviderProtocol) {
         self.userSessionProvider = userSessionProvider
-        self.client = Client.Factory().getInstance(environment: .staging, userSession: userSessionProvider)
+        self.client = Client.Factory().getInstance(
+            environment: .staging,
+            userSession: userSessionProvider,
+            coroutineScope: nil
+        )
     }
 
     private var currentJob: KotlinJob?


### PR DESCRIPTION
### :pushpin: References
n/a

### :tophat: What is the goal?
<!-- Provide a description of the overall goal (you can usually copy the one from the issue) -->
Currently the control of the used CoroutineScope is not convenient and not applicable on a global level for the SDK, which changed with that.

### :see_no_evil: Parts covered
<!-- Mark none for utility changes (eq: CI) -->
- [ ] Android
- [x] Common
- [ ] iOS


### :unicorn: How is it being implemented?
<!-- Provide a description of the implementation -->
It adds a new optional Parameter `coroutineScope`, which can be used by a consumer to make the SDK run in a specific scope and not in the it's default background scope.
Please also verify it works with the ExampleApp, while reviewing the changes.

### :thinking: DOD Checklist
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
