### PR TITLE
[SDK-663] Add custom content type plugin

### DIFF
--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/RequestBuilder.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/RequestBuilder.kt
@@ -20,6 +20,7 @@ import care.data4life.datadonation.DataDonationSDK.Environment
 import care.data4life.datadonation.error.CoreRuntimeError
 import care.data4life.datadonation.networking.Networking.RequestBuilder.Companion.ACCESS_TOKEN_FIELD
 import care.data4life.datadonation.networking.Networking.RequestBuilder.Companion.ACCESS_TOKEN_VALUE_PREFIX
+import care.data4life.datadonation.networking.plugin.KtorPluginsContract
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
@@ -127,8 +128,24 @@ internal class RequestBuilder private constructor(
         }
     }
 
+    private fun resolveContentType(): ContentType? {
+        return if (useJson) {
+            ContentType.Application.Json
+        } else {
+            null
+        }
+    }
+
     private fun setContentType(builder: HttpRequestBuilder) {
-        if (useJson) {
+        val contentType = resolveContentType()
+
+        if (contentType is ContentType) {
+            builder.header(
+                KtorPluginsContract.CustomTypeHeader.replacementHeader,
+                contentType
+            )
+
+            // Note: This is necessary to keep the Serialization Plugin working
             builder.contentType(ContentType.Application.Json)
         }
     }

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentType.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentType.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.datadonation.networking.plugin
+
+import io.ktor.client.HttpClient
+import io.ktor.client.features.HttpClientFeature
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpRequestPipeline.Phases.Before
+import io.ktor.client.request.HttpSendPipeline.Phases.State
+import io.ktor.http.HeadersBuilder
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelineContext
+
+internal class HttpCustomContentType(
+    private val config: InternalConfig
+) {
+    class Config(
+        var replacementHeader: String? = null,
+        var amendmentHeader: String? = null,
+    ) {
+        fun toInternalConfig(): InternalConfig {
+            return InternalConfig(replacementHeader, amendmentHeader)
+        }
+    }
+
+    data class InternalConfig(
+        val replacementHeader: String? = null,
+        val amendmentHeader: String? = null,
+    )
+
+    companion object Feature : HttpClientFeature<Config, HttpCustomContentType> {
+        override val key: AttributeKey<HttpCustomContentType> = AttributeKey("HttpCustomContentType")
+
+        override fun prepare(block: Config.() -> Unit): HttpCustomContentType {
+            val config = Config().apply(block).toInternalConfig()
+
+            return HttpCustomContentType(config)
+        }
+
+        private fun headerFieldsToList(headerFields: String): List<String> {
+            return headerFields.trim('[')
+                .trim(']')
+                .split(", ")
+                .sorted()
+        }
+
+        private fun resolveHeaderFields(
+            headers: HeadersBuilder,
+            HeaderFieldName: String
+        ): List<String>? {
+            val headerFields = headers.get(HeaderFieldName)
+            headers.remove(HeaderFieldName)
+
+            return if (headerFields != null) {
+                headerFieldsToList(headerFields)
+            } else {
+                null
+            }
+        }
+
+        private fun addAcceptFields(
+            headers: HeadersBuilder,
+            headerFields: List<String>
+        ) {
+            headerFields.forEach { header ->
+                headers.append("Accept", header)
+            }
+        }
+
+        private fun applyReplacementHeader(
+            pipeline: PipelineContext<Any, HttpRequestBuilder>,
+            scope: HttpClient,
+            headerField: String
+        ) {
+            val headerFields = resolveHeaderFields(
+                pipeline.context.headers,
+                headerField
+            )
+
+            if (headerFields != null) {
+                setAccept(
+                    scope,
+                    headerFields
+                )
+            }
+        }
+
+        private fun setAccept(scope: HttpClient, headerFields: List<String>) {
+            scope.sendPipeline.intercept(State) {
+                this.context.headers.remove("Accept")
+                addAcceptFields(this.context.headers, headerFields)
+            }
+        }
+
+        private fun applyAmendmentHeader(
+            pipeline: PipelineContext<Any, HttpRequestBuilder>,
+            scope: HttpClient,
+            headerField: String
+        ) {
+            val headerFields = resolveHeaderFields(
+                pipeline.context.headers,
+                headerField
+            )
+
+            if (headerFields != null) {
+                addAccept(
+                    scope,
+                    headerFields
+                )
+            }
+        }
+
+        private fun addAccept(scope: HttpClient, headerFields: List<String>) {
+            scope.sendPipeline.intercept(State) {
+                addAcceptFields(this.context.headers, headerFields)
+            }
+        }
+
+        override fun install(feature: HttpCustomContentType, scope: HttpClient) {
+            scope.requestPipeline.intercept(Before) {
+                if (feature.config.replacementHeader is String) {
+                    applyReplacementHeader(
+                        this,
+                        scope,
+                        feature.config.replacementHeader
+                    )
+                }
+
+                if (feature.config.amendmentHeader is String) {
+                    applyAmendmentHeader(
+                        this,
+                        scope,
+                        feature.config.amendmentHeader
+                    )
+                }
+            }
+        }
+    }
+}

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeConfigurator.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeConfigurator.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.datadonation.networking.plugin
+
+internal object HttpCustomContentTypeConfigurator : KtorPluginsContract.HttpCustomContentTypeConfigurator {
+    override fun configure(
+        pluginConfiguration: HttpCustomContentType.Config,
+        subConfiguration: Any?
+    ) {
+        pluginConfiguration.replacementHeader = KtorPluginsContract.CustomTypeHeader.replacementHeader
+    }
+}

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/KtorPluginsContract.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/KtorPluginsContract.kt
@@ -52,7 +52,12 @@ internal interface KtorPluginsContract {
         val errorMapper: HttpErrorMapper? = null
     )
 
+    object CustomTypeHeader {
+        const val replacementHeader = "X-Custom-Type-Replacement"
+    }
+
     fun interface HttpSerializerConfigurator : Networking.HttpPluginConfigurator<JsonFeature.Config, JsonConfigurator>
     fun interface HttpLoggingConfigurator : Networking.HttpPluginConfigurator<Logging.Config, care.data4life.sdk.log.Logger>
     fun interface HttpResponseValidatorConfigurator : Networking.HttpPluginConfigurator<HttpCallValidator.Config, HttpResponseValidationConfiguration>
+    fun interface HttpCustomContentTypeConfigurator : Networking.HttpPluginConfigurator<HttpCustomContentType.Config, Any?>
 }

--- a/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/PluginKoin.kt
+++ b/data-donation-sdk/src/commonMain/kotlin/care/data4life/datadonation/networking/plugin/PluginKoin.kt
@@ -45,6 +45,11 @@ internal fun resolveKtorPlugins(): Module {
                         HttpSuccessfulResponseValidator,
                         HttpErrorMapper
                     )
+                ),
+                Networking.HttpPluginInstaller(
+                    HttpCustomContentType,
+                    HttpCustomContentTypeConfigurator,
+                    null
                 )
             )
         }

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowModuleTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/integration/ClientConsentFlowModuleTest.kt
@@ -335,8 +335,8 @@ class ClientConsentFlowModuleTest {
                     actual = request.headers,
                     expected = headersOf(
                         "Authorization" to listOf("Bearer ${UserSessionTokenProvider.sessionToken}"),
+                        "Accept-Charset" to listOf("UTF-8"),
                         "Accept" to listOf("application/json"),
-                        "Accept-Charset" to listOf("UTF-8")
                     )
                 )
 

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/RequestBuilderTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/RequestBuilderTest.kt
@@ -20,6 +20,8 @@ import care.data4life.datadonation.DataDonationSDK.Environment
 import care.data4life.datadonation.error.CoreRuntimeError
 import care.data4life.datadonation.networking.Networking.RequestBuilder.Companion.ACCESS_TOKEN_FIELD
 import care.data4life.datadonation.networking.Networking.RequestBuilder.Companion.ACCESS_TOKEN_VALUE_PREFIX
+import care.data4life.datadonation.networking.plugin.HttpCustomContentType
+import care.data4life.datadonation.networking.plugin.KtorPluginsContract
 import care.data4life.sdk.util.test.coroutine.runWithContextBlockingTest
 import care.data4life.sdk.util.test.ktor.HttpMockClientFactory.createHelloWorldMockClient
 import care.data4life.sdk.util.test.ktor.HttpMockClientResponseFactory.createHelloWorldOkResponse
@@ -366,6 +368,10 @@ class RequestBuilderTest {
                         useArrayPolymorphism = false
                     }
                 )
+            }
+
+            install(HttpCustomContentType) {
+                this.replacementHeader = KtorPluginsContract.CustomTypeHeader.replacementHeader
             }
 
             engine {

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/RequestBuilderTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/RequestBuilderTest.kt
@@ -29,6 +29,8 @@ import io.ktor.client.engine.mock.toByteReadPacket
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.headers
+import io.ktor.client.request.request
 import io.ktor.http.HttpMethod
 import io.ktor.http.URLProtocol
 import io.ktor.http.fullPath

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeConfiguratorTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeConfiguratorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.datadonation.networking.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HttpCustomContentTypeConfiguratorTest {
+    @Test
+    fun `It fulfils HttpCustomContentTypeConfigurator`() {
+        val configurator: Any = HttpCustomContentTypeConfigurator
+
+        assertTrue(configurator is KtorPluginsContract.HttpCustomContentTypeConfigurator)
+    }
+
+    @Test
+    fun `Given configure is called with a HttpCustomContentTypeConfig it sets the replacementHeader`() {
+        // Given
+        val config = HttpCustomContentType.Config()
+
+        // When
+        HttpCustomContentTypeConfigurator.configure(
+            config,
+            null
+        )
+
+        // Then
+        assertEquals(
+            actual = config.replacementHeader,
+            expected = "X-Custom-Type-Replacement"
+        )
+
+        assertNull(config.amendmentHeader)
+    }
+}

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/HttpCustomContentTypeTest.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2021 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.datadonation.networking.plugin
+
+import care.data4life.sdk.util.test.coroutine.runBlockingTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.features.HttpClientFeature
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HttpCustomContentTypeTest {
+    @Test
+    fun `It fulfils HttpClientFeature`() {
+        val feature: Any = HttpCustomContentType
+
+        assertTrue(feature is HttpClientFeature<*, *>)
+    }
+
+    @Test
+    fun `It has a key`() {
+        assertEquals(
+            actual = HttpCustomContentType.key.name,
+            expected = "HttpCustomContentType"
+        )
+    }
+
+    @Test
+    fun `Given the plugin was intalled without adding a ReplacementHeader or AmendmentHeader it does nothing`() {
+        val client = HttpClient(MockEngine) {
+            // Given
+            install(HttpCustomContentType)
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to listOf("*/*")
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com")
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a ReplacementHeader it ignores the header, if no content was given`() {
+        val client = HttpClient(MockEngine) {
+            // Given
+            install(HttpCustomContentType) {
+                this.replacementHeader = "X-CustomType"
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to listOf("*/*")
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com")
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a ReplacementHeader it replaces the ContentType header, if the ReplacementHeader contains a value`() {
+        // Given
+        val replacementHeader = "X-CustomType"
+        val expected = "text/plain"
+
+        val client = HttpClient(MockEngine) {
+
+            install(HttpCustomContentType) {
+                this.replacementHeader = replacementHeader
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to listOf(expected)
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com") {
+                this.header(replacementHeader, expected)
+            }
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a ReplacementHeader it replaces the ContentType header, with multiple values in lexical order`() {
+        // Given
+        val replacementHeader = "X-CustomType"
+        val expected = listOf("text/plain", "application/json")
+
+        val client = HttpClient(MockEngine) {
+
+            install(HttpCustomContentType) {
+                this.replacementHeader = replacementHeader
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to expected.sorted()
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com") {
+                this.header(replacementHeader, expected)
+            }
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a AmendmentHeader it ignores the header, if no content was given`() {
+        val client = HttpClient(MockEngine) {
+            // Given
+            install(HttpCustomContentType) {
+                this.amendmentHeader = "X-CustomType"
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to listOf("*/*")
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com")
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a AmendmentHeader it replaces the ContentType header, if the AmendmentHeader contains a value`() {
+        // Given
+        val replacementHeader = "X-CustomType"
+        val expected = "text/plain"
+
+        val client = HttpClient(MockEngine) {
+
+            install(HttpCustomContentType) {
+                this.amendmentHeader = replacementHeader
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to listOf("*/*", expected)
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com") {
+                this.header(replacementHeader, expected)
+            }
+        }
+    }
+
+    @Test
+    fun `Given the plugin was intalled with a AmendmentHeader it replaces the ContentType header, with multiple values in lexical order`() {
+        // Given
+        val replacementHeader = "X-CustomType"
+        val expected = listOf("text/plain", "application/json")
+
+        val client = HttpClient(MockEngine) {
+
+            install(HttpCustomContentType) {
+                this.amendmentHeader = replacementHeader
+            }
+
+            engine {
+                addHandler { request ->
+                    // Then
+                    assertEquals(
+                        actual = request.headers,
+                        expected = headersOf(
+                            "Accept-Charset" to listOf("UTF-8"),
+                            "Accept" to expected.toMutableList()
+                                .also { it.add("*/*") }
+                                .sorted()
+                        )
+                    )
+
+                    respondOk("Never mind")
+                }
+            }
+        }
+
+        // When
+        runBlockingTest {
+            client.get<String>("example.com") {
+                this.header(replacementHeader, expected)
+            }
+        }
+    }
+}

--- a/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/PluginKoinTest.kt
+++ b/data-donation-sdk/src/commonTest/kotlin/care/data4life/datadonation/networking/plugin/PluginKoinTest.kt
@@ -40,7 +40,7 @@ class PluginKoinTest {
         // Then
         assertEquals(
             actual = configuration.size,
-            expected = 3
+            expected = 4
         )
         assertEquals<Any>(
             actual = configuration[0],
@@ -67,6 +67,14 @@ class PluginKoinTest {
                     HttpSuccessfulResponseValidator,
                     HttpErrorMapper
                 )
+            )
+        )
+        assertEquals<Any>(
+            actual = configuration[3],
+            expected = Networking.HttpPluginInstaller(
+                HttpCustomContentType,
+                HttpCustomContentTypeConfigurator,
+                null
             )
         )
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** [SDK-663](https://gesundheitscloud.atlassian.net/browse/SDK-663)

### :tophat: What is the goal?
<!-- Provide a description of the overall goal (you can usually copy the one from the issue) -->
Currently Ktor is missing a way to propagate a custom content type on runtime (see [here](https://github.com/ktorio/ktor/issues/1127) for more), which is solved by this PR and is needed for the donation flow.

### :unicorn: How is it being implemented?
<!-- Provide a description of the implementation -->
It add a new Plugin and invokes it in the current NetworkModel.

### :thinking: DOD Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
- [ ] I have updated the changelog accordingly.
